### PR TITLE
#25 fix for EJTSERVER_LICENSES_FILE

### DIFF
--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -86,7 +86,7 @@ ln -sf /data/users.txt ${EJTSERVER_PATH}/users.txt
 
 # Check licenses
 echo "Checking licenses..."
-if [ -z "$EJTSERVER_LICENSES" ]; then
+if [[ -z "$EJTSERVER_LICENSES" && -z "$EJTSERVER_LICENSES_FILE" ]]; then
   echo "FATAL: At least one license is required to start the license server"
   exit 1
 fi


### PR DESCRIPTION
Fixes #25 

exit only if neither of
EJTSERVER_LICENSES
EJTSERVER_LICENSES_FILE
are specified