### PR TITLE
Fixed need of root permissions, included vmOption overrides

### DIFF
--- a/README.md
+++ b/README.md
@@ -88,6 +88,7 @@ linux/s390x
 * `EJTSERVER_LICENSES`: Your floating licenses (comma delimited)
 * `EJTSERVER_DISPLAY_HOSTNAMES`: If you want to see host names instead of IP addresses (default `false`)
 * `EJTSERVER_LOG_LEVEL`: [Log4J log level](https://logging.apache.org/log4j/2.x/manual/customloglevels.html) of the EJT License Server (default `INFO`)
+* `EJTSERVER_VMOPTIONS`: Can be specified if you want to append some vmoptions to the ejtserver jvm
 
 > 💡 `EJT_ACCOUNT_USERNAME_FILE`, `EJT_ACCOUNT_PASSWORD_FILE` and
 > `EJTSERVER_LICENSES_FILE` can be used to fill in the value from a file,

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -121,6 +121,10 @@ log4j.appender.stdout.layout=org.apache.log4j.PatternLayout
 log4j.appender.stdout.layout.ConversionPattern=[%p] - %d{ISO8601} - %m%n
 EOL
 
+# VM Options
+echo "Updating VMOptions..."
+echo "${EJTSERVER_VMOPTIONS}" >> ${EJTSERVER_PATH}/bin/ejtserver.vmoptions
+
 # Check if any files or directories have incorrect ownership
 if find /data "${EJTSERVER_PATH}" ! -user ejt -o ! -group ejt | grep -q .; then
   if [ "$(id -u)" -eq 0 ]; then

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -46,10 +46,14 @@ if [ -n "${PUID}" ] && [ "${PUID}" != "$(id -u ejt)" ]; then
   sed -i -e "s/^ejt:\([^:]*\):[0-9]*:\([0-9]*\)/ejt:\1:${PUID}:\2/" /etc/passwd
 fi
 
-# Timezone
-echo "Setting timezone to ${TZ}..."
-ln -snf /usr/share/zoneinfo/${TZ} /etc/localtime
-echo ${TZ} > /etc/timezone
+# Check if the script has root privileges and update timezone, if possible
+if [ "$(id -u)" -eq 0 ]; then
+    ln -snf /usr/share/zoneinfo/${TZ} /etc/localtime
+    echo "${TZ}" > /etc/timezone
+    echo "Timezone successfully set to ${TZ}."
+else
+    echo "You do not have root privileges. The current timezone stays at ${TZ}."
+fi
 
 # Download ejtserver tarball
 file_env 'EJT_ACCOUNT_USERNAME'


### PR DESCRIPTION
This PR includes two main fixes:
- check permissions, before executing the `chown` and the timezone change. This addresses #48
- added the possibility to override the VM_OPTIONS via `EJTSERVER_VMOPTIONS` (e.g. for limiting the allocated ram via `-Xmx`)